### PR TITLE
Permit custom API URL and remove `staging` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,17 @@ UsherJS can be instantiated by optionally passing a `config` object.
 const usher = Usher();
 
 // or
-const usher2 = Usher({ });
+const usher2 = Usher({ apiUrl: "https://app.staging.usher.so/api" });
+
+// or
+const usher3 = Usher({ apiUrl: "<YOUR_USHER_NODE_URL>/api" });
 ```
 
 #### Options
 
 |**Option**|**Type**|**Default**|**Description**
 |----------|--------|-----------|---------------
+|`apiUrl`|string|"https://app.usher.so/api"|The URL to the Usher API to use for Conversion Tracking
 |`conflictStrategy`|string (enum)|"passthrough"|An enum to indicate how to handle conflicting tokens for the same campaign. The option can be either be `"passthrough"` or `"overwrite"`. In the "passthrough" scenario, referal tokens are backlogged for the same campaign. Any previously tracked referral token is saved to the browser until it expires or is used. In the "overwrite", any new referral token that is saved overwrites other saved tokens relative to the same campaign.
 
 ### Methods
@@ -115,8 +119,24 @@ usher.convert({
 
 ## 🧑‍💻 Testing Integration
 
-[//]: # (TODO add staging url)
-To test your integration of UsherJS, be sure to configure using `Usher({ })` and then use one of the Test Campaigns over at the [Usher Staging Environment](https://app.staging.usher.so/)!
+To test your integration of UsherJS, be sure to configure using `Usher({ apiUrl })`. You can use our [Usher Staging Environment](https://app.staging.usher.so/), or you can use your own Usher Node.
+
+[Learn more on how to create an Usher Node →](https://github.com/usherlabs/usher)
+
+### Testing with Usher Staging Environment
+
+You may use our Staging Environment to test your integration of UsherJS. To do so, you will need to:
+
+- Set the `apiUrl` option when instantiating UsherJS to `https://app.staging.usher.so/api`
+- Use one of the Test Campaigns over at the [Usher Staging Environment](https://app.staging.usher.so/).
+
+
+### Testing with other Usher Nodes
+
+Another option is to use your own Usher Node. You can do so by setting the `apiUrl` option when instantiating UsherJS. To do so, you will need to:
+
+- Set the `apiUrl` options when instantiating UsherJS to the URL of your Usher Node. (e.g. on local development: `http://localhost:3000/api`)
+
 
 ## 🐒 Development
 
@@ -136,3 +156,5 @@ yarn local
 
 Then, make your changes and test them out using the [test Campaign on the Usher Staging Environment](https://app.staging.usher.so/campaign/arweave/ida4Pebl2uULdI_rN8waEw65mVH9uIFTY1JyeZt1PBM)!
 This specific Test Campaign has a destination URL [http://localhost:3001/](http://localhost:3001/)
+
+You may also use your own Usher node to develop.

--- a/README.md
+++ b/README.md
@@ -74,14 +74,13 @@ UsherJS can be instantiated by optionally passing a `config` object.
 const usher = Usher();
 
 // or
-const usher2 = Usher({ staging: true });
+const usher2 = Usher({ });
 ```
 
 #### Options
 
 |**Option**|**Type**|**Default**|**Description**
 |----------|--------|-----------|---------------
-|`staging`|boolean|false|A flag to indicate whether to use a [Staging Environment](https://app.staging.usher.so) for Testing/Integration Purposes, or the [Live Environment](https://app.usher.so)
 |`conflictStrategy`|string (enum)|"passthrough"|An enum to indicate how to handle conflicting tokens for the same campaign. The option can be either be `"passthrough"` or `"overwrite"`. In the "passthrough" scenario, referal tokens are backlogged for the same campaign. Any previously tracked referral token is saved to the browser until it expires or is used. In the "overwrite", any new referral token that is saved overwrites other saved tokens relative to the same campaign.
 
 ### Methods
@@ -116,7 +115,8 @@ usher.convert({
 
 ## 🧑‍💻 Testing Integration
 
-To test your integration of UsherJS, be sure to configure using `Usher({ staging: true })` and then use one of the Test Campaigns over at the [Usher Staging Environment](https://app.staging.usher.so/)!
+[//]: # (TODO add staging url)
+To test your integration of UsherJS, be sure to configure using `Usher({ })` and then use one of the Test Campaigns over at the [Usher Staging Environment](https://app.staging.usher.so/)!
 
 ## 🐒 Development
 

--- a/src/configure.ts
+++ b/src/configure.ts
@@ -1,4 +1,4 @@
-import { apiUrl, stagingApiUrl } from "@/env-config";
+import { apiUrl } from "@/env-config";
 import { Config, ConflictStrategy } from "@/types";
 
 class Configure {

--- a/src/configure.ts
+++ b/src/configure.ts
@@ -15,12 +15,11 @@ class Configure {
 	}
 
 	public static use(config: Config) {
-		if (typeof config.staging === "boolean") {
-			if (config.staging === true) {
-				this._apiUrl = stagingApiUrl;
-			} else {
-				this._apiUrl = apiUrl;
-			}
+		// What api url will usher use?
+		// 1. If apiUrl is set by the user, use that
+		// 2. Otherwise, use the default apiUrl
+		if (typeof config.apiUrl === "string") {
+			this._apiUrl = config.apiUrl;
 		}
 		if (typeof config.conflictStrategy === "string") {
 			const strats = Object.values(ConflictStrategy);

--- a/src/env-config.ts
+++ b/src/env-config.ts
@@ -6,7 +6,6 @@ export const appVersion = process.env.APP_VERSION;
 export const appName = `${appPackageName}@${appVersion}`;
 
 export const apiUrl = process.env.API_URL;
-export const stagingApiUrl = process.env.STAGING_API_URL;
 
 if (!apiUrl) {
 	console.log(`[USHER] ERROR: No API Url loaded!`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,6 @@ export enum ConflictStrategy {
 
 export type Config = {
 	apiUrl?: string;
-	staging?: boolean;
 	conflictStrategy?: ConflictStrategy;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export enum ConflictStrategy {
 }
 
 export type Config = {
+	apiUrl?: string;
 	staging?: boolean;
 	conflictStrategy?: ConflictStrategy;
 };

--- a/tools/index.html
+++ b/tools/index.html
@@ -12,8 +12,7 @@
 		<script src="/build/index.js"></script>
 		<script>
 			var responseEl = document.querySelector("#response");
-			// todo - add staging url
-			const usher = window.Usher({  })
+			const usher = window.Usher({ apiUrl: "https://app.staging.usher.so/api" })
 			responseEl.innerHTML += "<p>Yes, I'm here...</p>";
 			usher.anchor("#anchor-el", {
 				id: "ida4Pebl2uULdI_rN8waEw65mVH9uIFTY1JyeZt1PBM",

--- a/tools/index.html
+++ b/tools/index.html
@@ -12,7 +12,8 @@
 		<script src="/build/index.js"></script>
 		<script>
 			var responseEl = document.querySelector("#response");
-			const usher = window.Usher({ staging: true })
+			// todo - add staging url
+			const usher = window.Usher({  })
 			responseEl.innerHTML += "<p>Yes, I'm here...</p>";
 			usher.anchor("#anchor-el", {
 				id: "ida4Pebl2uULdI_rN8waEw65mVH9uIFTY1JyeZt1PBM",


### PR DESCRIPTION
Highlights
- add new parameter `apiUrl` to config
- update documentation about `apiUrl` parameter usage
- removes `staging` parameter from config
- removes documentation about `staging`
